### PR TITLE
Group teams in teams menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Required keys and configuration are defined as env variables:
 You add env vars via an `.env` file in the project root. Example:
 
 ```
-TORNEOPAL_API_KEY=
-TORNEOPAL_CLUB_ID=
-TORNEOPAL_COMPETITION_ID=
+TORNEOPAL_API_KEY=abcde12345
+TORNEOPAL_CLUB_ID=79
+TORNEOPAL_COMPETITION_ID=etejp24
 MOCK_TORNEOPAL_REQUESTS=false
 ```

--- a/src/components/DateBadge.astro
+++ b/src/components/DateBadge.astro
@@ -10,7 +10,7 @@ type Props = {
 const { date, isCompleted } = Astro.props;
 
 const weekday = format(date, "EEEEEE", { locale: fi });
-const dateStr = format(date, "dd.MM");
+const dateStr = format(date, "d.M.");
 ---
 
 <div>

--- a/src/components/Fixture.astro
+++ b/src/components/Fixture.astro
@@ -24,28 +24,29 @@ const {
 const timeStr = time.slice(0, time.length - 3);
 ---
 
-<DateBadge date={date} isCompleted={isCompleted} />
-<div>
-  <span> {competition}:</span>
-  <span>
-    {
-      homeTeamName
-    }
-    {homeScore}
-  </span>{" "}
-  -{" "}
-  <span>
-    {awayScore}
-    {
-      awayTeamName
-    }
-  </span>
+<div style="display: flex; gap: 20px; margin-bottom: 10px;">
+  <DateBadge date={date} isCompleted={isCompleted} />
+  <div>
+    <div>
+      {competition}:
+      {
+        homeTeamName
+      }
+      {homeScore}
+    </span>{" "}
+    -{" "}
+    <span>
+      {awayScore}
+      {
+        awayTeamName
+      }
+    </div>
+    <div>
+      klo {timeStr}{" "}
+      <span>
+        {venue}
+        {city ? `, ${city}` : ""}
+      </span>
+    </div>
+  </div>
 </div>
-<div>
-  klo {timeStr}{" "}
-  <span>
-    {venue}
-    {city ? `, ${city}` : ""}
-  </span>
-</div>
-<br />

--- a/src/components/FixtureList/CollapsibleContainer.astro
+++ b/src/components/FixtureList/CollapsibleContainer.astro
@@ -1,0 +1,49 @@
+---
+type Props = {
+  heading: HTMLElement;
+  isOpen?: boolean;
+}
+
+const { heading, isOpen = false } = Astro.props;
+---
+
+<collapsible-container style="display: flex; gap: 10px; cursor: pointer;">
+  <div data-icon-close style={`display: ${isOpen ? "" : "none"};`}>▲</div>
+  <div data-icon-open style={`display: ${!isOpen ? "" : "none"};`}>▼</div>
+  <div>
+    <div data-heading>{heading}</div>
+    <div data-children style={`display: ${isOpen ? "" : "none"};`}>
+      <slot />
+    </div>
+  </div>
+</collapsible-container>
+
+
+<script>
+  class CollapsibleContainer extends HTMLElement {
+    constructor() {
+      super();
+      
+      const heading: HTMLElement | null = this.querySelector('[data-heading]')
+      const children: HTMLElement | null = this.querySelector('[data-children]')
+      const iconOpen: HTMLElement | null = this.querySelector('[data-icon-open]')
+      const iconClose: HTMLElement | null = this.querySelector('[data-icon-close]')
+      
+      let isOpen = children?.style.display !== "none";
+
+      const toggleCollapse = () => {
+        isOpen = !isOpen;
+
+        if (children) children.style.display = isOpen ? "" : "none";
+        if (iconClose) iconClose.style.display = isOpen ? "" : "none"
+        if (iconOpen) iconOpen.style.display = !isOpen ? "" : "none"
+      }
+
+      heading?.addEventListener('click', toggleCollapse);
+      iconOpen?.addEventListener('click', toggleCollapse);
+      iconClose?.addEventListener('click', toggleCollapse);
+    }
+  }
+
+  customElements.define('collapsible-container', CollapsibleContainer);
+</script>

--- a/src/components/FixtureList/FixtureList.astro
+++ b/src/components/FixtureList/FixtureList.astro
@@ -66,7 +66,11 @@ const matches = await getAllMatchesForClub();
       }
       
       checkboxes.forEach(checkbox => checkbox.addEventListener('click', () => {
-        setTeamFilterState({ ...getTeamFilterState(), [checkbox.id]: checkbox.checked });
+        const updatedState = Object.values(checkboxes).reduce((state, input) => 
+          (input.checked) ? {...state, [input.id]: true} : state
+        , {})
+
+        setTeamFilterState(updatedState);
         updateFixtureList();
       }));
 

--- a/src/components/FixtureList/FixtureList.astro
+++ b/src/components/FixtureList/FixtureList.astro
@@ -44,7 +44,7 @@ const matches = await getAllMatchesForClub();
       }
 
       const toggleAllFixtures = (visible: boolean) => {
-        const allFixtures = this.querySelectorAll('[data-team-id]') as NodeListOf<HTMLElement>;
+        const allFixtures: NodeListOf<HTMLElement> = this.querySelectorAll('[data-team-id]');
         allFixtures.forEach(fixture => fixture.style.display = visible ? "" : "none");
       }
 
@@ -60,7 +60,7 @@ const matches = await getAllMatchesForClub();
         Object.entries(filterState).forEach(([key, value]) => {
           if (!value) return;
 
-          const teamFixtures = this.querySelectorAll(`[data-team-id="${key}"]`) as NodeListOf<HTMLElement>;
+          const teamFixtures: NodeListOf<HTMLElement> = this.querySelectorAll(`[data-team-id="${key}"]`);
           teamFixtures.forEach(fixture => fixture.style.display = "");
         });
       }

--- a/src/components/FixtureList/FixtureList.astro
+++ b/src/components/FixtureList/FixtureList.astro
@@ -1,24 +1,17 @@
 ---
 import { isValid } from "date-fns";
 
-import { getAllMatchesForClub, getAllTeamsForClub } from "../api/torneoPal";
+import { getAllMatchesForClub, getAllTeamsForClub } from "../../api/torneoPal";
 
-import Fixture from "./Fixture.astro";
+import Fixture from "../Fixture.astro";
+import TeamsMenu from "./TeamsMenu.astro";
 
 const teams = await getAllTeamsForClub();
 const matches = await getAllMatchesForClub();
 ---
 
 <fixture-list style="display: flex; gap: 30px">
-  <div>
-    {teams
-      .map((team) => 
-      <div>
-        <input type="checkbox" data-filter-checkbox id={team.id} name={`${team.ageGroup}-${team.name}`} />
-        <label for={team.id}>{team.primaryCategoryName}-{team.name}</label>
-      </div>
-    )}
-  </div>
+  <TeamsMenu teams={teams} />
   <div>
     {matches
       .filter(({ date }) => isValid(date))
@@ -36,7 +29,7 @@ const matches = await getAllMatchesForClub();
 </fixture-list>
 
 <script>
-  import { getTeamFilterState, setTeamFilterState } from "../state/teamFilterState";
+  import { getTeamFilterState, setTeamFilterState } from "../../state/teamFilterState";
 
   class FixtureList extends HTMLElement {
     constructor() {

--- a/src/components/FixtureList/TeamCheckbox.astro
+++ b/src/components/FixtureList/TeamCheckbox.astro
@@ -1,0 +1,14 @@
+---
+import type { Team } from '../../types/Team'
+
+type Props = {
+  team: Team;
+};
+
+const { team } = Astro.props;
+---
+
+<div>
+  <input type="checkbox" data-filter-team id={team.id} name={`${team.ageGroup}-${team.name}`} />
+  <label style="cursor: pointer;" for={team.id}>{team.name} ({team.ageGroup})</label>
+</div>

--- a/src/components/FixtureList/TeamsMenu.astro
+++ b/src/components/FixtureList/TeamsMenu.astro
@@ -1,19 +1,44 @@
 ---
+import { groupBy } from 'ramda';
 import type { Team } from '../../types/Team';
 
 type Props = {
   teams: Team[];
 };
 
+const categoryMap: Record<string, string> = {
+  "M": "Miehet",
+  "N": "Naiset",
+  "P": "Pojat",
+  "T": "Tytöt",
+};
+
 const { teams } = Astro.props;
+const groupTeamsByCategory = groupBy((team: Team) => {
+  const prefix = team.ageGroup.charAt(0);
+  return categoryMap[prefix] ?? 'unknown';
+});
+
+const teamsByCategory = groupTeamsByCategory(teams);
+
+console.log(Object.values(teamsByCategory).map(teams => teams?.map(team => team.ageGroup)))
 ---
 
 <div>
-  {teams
-    .map((team) => 
+  {Object.entries(teamsByCategory).map(([group, teams = []]) => {
+    if (teams.length === 0) return;
+
+    return (
       <div>
-        <input type="checkbox" data-filter-checkbox id={team.id} name={`${team.ageGroup}-${team.name}`} />
-        <label for={team.id}>{team.primaryCategoryName}-{team.name}</label>
+        <h3>{group}</h3>
+        {teams
+          .map((team) => 
+            <div>
+              <input type="checkbox" data-filter-checkbox id={team.id} name={`${team.ageGroup}-${team.name}`} />
+              <label for={team.id}>{team.primaryCategoryName}-{team.name}</label>
+            </div>
+        )}
       </div>
-  )}
+    )
+  })}
 </div>

--- a/src/components/FixtureList/TeamsMenu.astro
+++ b/src/components/FixtureList/TeamsMenu.astro
@@ -26,7 +26,7 @@ const groupTeamsByCategory = groupBy((team: Team) => {
 const teamsByCategory = groupTeamsByCategory(teams);
 ---
 
-<div>
+<div style="min-width: 260px;">
   {Object.entries(teamsByCategory).map(([category, teamsInCategory = []]) => {
     if (teamsInCategory.length === 0) return;
     

--- a/src/components/FixtureList/TeamsMenu.astro
+++ b/src/components/FixtureList/TeamsMenu.astro
@@ -1,6 +1,10 @@
 ---
 import { groupBy } from 'ramda';
+
 import type { Team } from '../../types/Team';
+
+import CollapsibleContainer from './CollapsibleContainer.astro';
+import TeamCheckbox from './TeamCheckbox.astro';
 
 type Props = {
   teams: Team[];
@@ -20,25 +24,39 @@ const groupTeamsByCategory = groupBy((team: Team) => {
 });
 
 const teamsByCategory = groupTeamsByCategory(teams);
-
-console.log(Object.values(teamsByCategory).map(teams => teams?.map(team => team.ageGroup)))
 ---
 
 <div>
-  {Object.entries(teamsByCategory).map(([group, teams = []]) => {
-    if (teams.length === 0) return;
-
+  {Object.entries(teamsByCategory).map(([category, teamsInCategory = []]) => {
+    if (teamsInCategory.length === 0) return;
+    
+    const categoryHeading = <strong>{category}</strong>;
+    
+    if (teamsInCategory.length < 10) {
+      return (
+        <CollapsibleContainer heading={categoryHeading}>
+          {teamsInCategory.map((team) => <TeamCheckbox team={team} />)}
+        </CollapsibleContainer>
+      );
+    };
+        
+    const teamsByAgeGroup = groupBy((team: Team) => team.ageGroup)(teamsInCategory);
+    
     return (
-      <div>
-        <h3>{group}</h3>
-        {teams
-          .map((team) => 
-            <div>
-              <input type="checkbox" data-filter-checkbox id={team.id} name={`${team.ageGroup}-${team.name}`} />
-              <label for={team.id}>{team.primaryCategoryName}-{team.name}</label>
-            </div>
-        )}
-      </div>
-    )
+      <CollapsibleContainer heading={categoryHeading}>
+        {Object.entries(teamsByAgeGroup).map(([ageGroup, teamsInAgeGroup]) => {
+          if (!teamsInAgeGroup) return;
+          if (teamsInAgeGroup.length === 1) return <TeamCheckbox team={teamsInAgeGroup[0]} />;
+
+          const groupHeading = <div>{ageGroup}</div>;
+
+          return (
+            <CollapsibleContainer heading={groupHeading}>
+              {teamsInAgeGroup.map((team) => <TeamCheckbox team={team} />)}
+            </CollapsibleContainer>
+          );
+        })}
+      </CollapsibleContainer>
+    );
   })}
 </div>

--- a/src/components/FixtureList/TeamsMenu.astro
+++ b/src/components/FixtureList/TeamsMenu.astro
@@ -1,0 +1,19 @@
+---
+import type { Team } from '../../types/Team';
+
+type Props = {
+  teams: Team[];
+};
+
+const { teams } = Astro.props;
+---
+
+<div>
+  {teams
+    .map((team) => 
+      <div>
+        <input type="checkbox" data-filter-checkbox id={team.id} name={`${team.ageGroup}-${team.name}`} />
+        <label for={team.id}>{team.primaryCategoryName}-{team.name}</label>
+      </div>
+  )}
+</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import FixtureList from '../components/FixtureList.astro';
+import FixtureList from '../components/FixtureList/FixtureList.astro';
 ---
 
 <Layout title="Ottelut - Helsingin Ponnistus">

--- a/todo.txt
+++ b/todo.txt
@@ -12,18 +12,18 @@
 [ ] group teams in filters by category
     - "Tytöt", "Pojat", "Naiset", "Miehet" -- match.category_group_name
 
-[ ] results for finished fixtures
-    - display goals for teams when available
-
-[ ] upcoming only -filter
-    - hide all finished fixtures (date or finished info in data?)
-    
 [ ] group teams in filters by age group
     - if more than one team in age group -- match.age_group, match.category_name
 
-[ ] add styles to app
+[ ] results for finished fixtures
+    - display goals for teams when available
 
 [ ] setup ci/cd
+
+[ ] add styles to app
+
+[ ] upcoming only -filter
+    - hide all finished fixtures (date or finished info in data?)    
 
 ---------- V1.0 ----------
 

--- a/todo.txt
+++ b/todo.txt
@@ -9,21 +9,40 @@
     - if none selected, display all fixtures
     - persist selections across sessions (per browser)
 
-[ ] group teams in filters by category
+[X] group teams in filters by category
     - "Tytöt", "Pojat", "Naiset", "Miehet" -- match.category_group_name
 
-[ ] group teams in filters by age group
+[X] group teams in filters by age group
+    - if more than ten teams in category
     - if more than one team in age group -- match.age_group, match.category_name
+
+[X] collapsible team filters
+    - category and age group collapsible
+
+[ ] display selected teams as a list below(?) filters
+    - each with a "remove" button (an "X" maybe?)
+
+[ ] add headings
+    - check accessibility
+
+[ ] add basic styles to app
+
+[ ] add mobile styles
+    - how should the filters work on a narrow viewport?
+
+[ ] setup ci/cd
+
+---------- BETA ----------
+
+[ ] persist collapse states across sessions (per browser)
 
 [ ] results for finished fixtures
     - display goals for teams when available
 
-[ ] setup ci/cd
-
-[ ] add styles to app
-
 [ ] upcoming only -filter
     - hide all finished fixtures (date or finished info in data?)    
+
+[ ] set up domain (ponnarit.fi, setup subdomain ottelut)
 
 ---------- V1.0 ----------
 


### PR DESCRIPTION
Group team selection checkboxes in collapsible group in the teams menu by category ("Miehet", "Naiset", "Pojat", "Tytöt") and by age group. Age grouping done when:
- the category has more than ten teams
- the age group has more than one team

Contains also:
- simple updates to overall layout -- improve readability, app styling TBD
- improvements in filter persisting -- do not persist selections for non-existing filters
- add values in the env var example in readme

![2024-04-03 11 34 43](https://github.com/lehtoinen/ottelut.ponnarit.fi/assets/6904260/011b97ff-3340-4f57-80c8-f964d81f9f4b)
