### PR TITLE
Fix site root folder

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,7 @@
+import { loadEnv } from "vite";
 import { defineConfig } from 'astro/config';
 
-const {
-  ASTRO_BASE,
-  ASTRO_SITE,
-} = import.meta.env;
+const { ASTRO_BASE, ASTRO_SITE } = loadEnv(process.env.NODE_ENV, process.cwd(), "");
 
 // https://astro.build/config
 export default defineConfig({


### PR DESCRIPTION
Use `loadEnv` to access env vars in Astro config.