### PR TITLE
Improve results

### DIFF
--- a/src/components/DateBadge.astro
+++ b/src/components/DateBadge.astro
@@ -4,17 +4,15 @@ import { fi } from "date-fns/locale/fi";
 
 type Props = {
   date: Date;
-  isCompleted: boolean;
 };
 
-const { date, isCompleted } = Astro.props;
+const { date } = Astro.props;
 
 const weekday = format(date, "EEEEEE", { locale: fi });
 const dateStr = format(date, "d.M.");
 ---
 
 <div>
-  <div>{isCompleted ? "Pelattu" : ""}</div>
   <div>{weekday}</div>
   <div>{dateStr}</div>
 </div>

--- a/src/components/Fixture.astro
+++ b/src/components/Fixture.astro
@@ -11,7 +11,6 @@ const { fixture } = Astro.props;
 const {
   date,
   time,
-  isCompleted,
   competition,
   venue,
   city,
@@ -25,7 +24,7 @@ const timeStr = time.slice(0, time.length - 3);
 ---
 
 <div style="display: flex; gap: 20px; margin-bottom: 10px;">
-  <DateBadge date={date} isCompleted={isCompleted} />
+  <DateBadge date={date} />
   <div>
     <div>
       {competition}:

--- a/src/components/Fixture.astro
+++ b/src/components/Fixture.astro
@@ -28,9 +28,14 @@ const timeStr = time.slice(0, time.length - 3);
   <div>
     <div>
       {competition}:
-      {homeTeamName}
-      {homeScore} - {awayScore}
-      {awayTeamName}
+      <span class={homeScore > awayScore ? "winner" : ""}>
+        {homeTeamName}
+      </span>
+      {homeScore} -
+      {awayScore}
+      <span class={homeScore < awayScore ? "winner" : ""}>
+        {awayTeamName}
+      </span>
       <div>
         klo {timeStr}{" "}
         <span>
@@ -41,3 +46,9 @@ const timeStr = time.slice(0, time.length - 3);
     </div>
   </div>
 </div>
+
+<style>
+  .winner {
+    font-weight: 700;
+  }
+</style>

--- a/src/components/FixtureList/FixtureList.astro
+++ b/src/components/FixtureList/FixtureList.astro
@@ -5,29 +5,51 @@ import { getAllMatchesForClub, getAllTeamsForClub } from "../../api/torneoPal";
 
 import Fixture from "../Fixture.astro";
 import TeamsMenu from "./TeamsMenu.astro";
+import { partition } from "ramda";
+import type { Match } from "../../types/Match";
 
 const teams = await getAllTeamsForClub();
-const matches = await getAllMatchesForClub();
+const matches = (await getAllMatchesForClub()).filter(({ date }) =>
+  isValid(date)
+);
+
+const [completed, upcoming] = partition(
+  ({ isCompleted }) => isCompleted,
+  matches
+);
 ---
 
 <fixture-list>
   <TeamsMenu teams={teams} />
   <div>
     <h2>Ottelut</h2>
+    <h3>Pelatut</h3>
     {
-      matches
-        .filter(({ date }) => isValid(date))
-        .map((match) => {
-          const teamId = teams.find((team) =>
-            [match.homeTeamId, match.awayTeamId].includes(team.id)
-          )?.id;
+      completed.map((match) => {
+        const teamId = teams.find((team) =>
+          [match.homeTeamId, match.awayTeamId].includes(team.id)
+        )?.id;
 
-          return (
-            <div data-team-id={teamId}>
-              <Fixture fixture={match} />
-            </div>
-          );
-        })
+        return (
+          <div data-team-id={teamId}>
+            <Fixture fixture={match} />
+          </div>
+        );
+      })
+    }
+    <h3>Tulevat</h3>
+    {
+      upcoming.map((match) => {
+        const teamId = teams.find((team) =>
+          [match.homeTeamId, match.awayTeamId].includes(team.id)
+        )?.id;
+
+        return (
+          <div data-team-id={teamId}>
+            <Fixture fixture={match} />
+          </div>
+        );
+      })
     }
   </div>
 </fixture-list>

--- a/todo.txt
+++ b/todo.txt
@@ -29,24 +29,25 @@
 
 [X] setup ci/cd
 
-[ ] add basic styles to app
+[X] add basic styles to app
 
 ---------- BETA ----------
 
-[ ] display selected teams as a list below(?) filters
+[X] results for finished fixtures
+    - display goals for teams when available
+
+[ ] display selected teams as a list above(?) filters
     - each with a "remove" button (an "X" maybe?)
 
 [ ] persist collapse states across sessions (per browser)
 
 [ ] set up domain (ponnarit.fi, setup subdomain ottelut)
 
+[ ] add site meta
+
 ---------- V1.0 ----------
 
-[ ] results for finished fixtures
-    - display goals for teams when available
-
-[ ] upcoming only -filter
-    - hide all finished fixtures (date or finished info in data?)    
+[ ] separate pages for upcoming matches and results
 
 ---------- V1.1 ----------
 


### PR DESCRIPTION
Separate the results from upcoming matches in the fixtures list.
- add subheading for results and upcoming
- tune results:
  - drop the "finished" tag from results
  - highlight the winner